### PR TITLE
v0.2.0 Add nextOnError functionality and refactor handleError

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,31 @@ In this example, incoming GET requests to the root (/) will have their query par
 
 This process can be repeated for all the routes you wish to validate, adjusting the schema and target as needed.
 
+### `nextOnError` option
+The nextOnError option is a new feature in the simply-joi-middleware package. This is an optional setting that allows developers to customize how the middleware behaves when validation fails.
+
+By default, if a validation error occurs, `simply-joi-middleware` will terminate the request-response cycle by sending an HTTP error 400 Bad Request and will not call the `next()` function.
+
+However, with the `nextOnError` option, you can override this behavior. When `nextOnError` is set to true, the middleware will call the `next(err)` function and pass control to the next middleware in the stack if the validation fails.
+
+Here's a code example that shows how to use this option:
+
+```ts
+const AppRouter: Router = Router();
+const schema = Joi.object({
+    name: Joi.string().required()
+});
+
+const validationMiddleware = validate(schema, Targets.QUERY, undefined, {nextOnError: true});
+
+AppRouter.get('/', validationMiddleware, AppController);
+```
+
+In this example, if the `name` query parameter is not provided or invalid, the `validationMiddleware` will call `next(err)`. This allows you to handle the error in subsequent middleware or error handlers as per your application's error handling strategy.
+
+This provides more control over how validation errors are handled in your application and can be particularly useful when you want to include additional logging, error transformations or other custom error handling logic after a validation failure.
+
+
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -9,13 +9,10 @@
     "url": "https://github.com/marcosppollastri/simply-joi-middleware"
   },
   "scripts": {
-    "start": "node dist/app.js",
-    "dev": "ts-node-dev --respawn --transpile-only -r tsconfig-paths/register src/app.ts",
     "build": "tsc",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
     "test": "jest --forceExit",
-    "test:watch": "jest --forceExit --watch ",
     "test:cov": "jest --coverage --forceExit",
     "prepublishOnly": "npm run build",
     "prepare": "npm run build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simply-joi-middleware",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A simple middleware library for using Joi schemas validations on express",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -72,7 +72,8 @@
       "/dist/",
       "/test/",
       "/node_modules/",
-      "/.eslintrc\\.js"
+      "/.eslintrc\\.js",
+      "/src/index\\.ts"
     ],
     "testEnvironment": "node",
     "moduleNameMapper": {

--- a/src/helpers/handleError.ts
+++ b/src/helpers/handleError.ts
@@ -1,0 +1,39 @@
+import { HttpError } from '@supercharge/http-errors/dist';
+import { NextFunction, Response } from 'express';
+import {isError as isJoiError } from 'joi';
+import { SimplyJoiOptions } from '..';
+
+/**
+ * Handles errors that occur during Joi schema validation.
+ *
+ * If the `nextOnError` option is set to `true` in the `SimplyJoiOptions`,
+ * the Express 'next' function is called with the error.
+ * Otherwise, an HTTP response with an error status code and error message is sent.
+ *
+ * @param {unknown} error - The error thrown during Joi schema validation.
+ * @param {SimplyJoiOptions} [options] - The optional options for the validation middleware.
+ * @param {Response} [res] - The Express HTTP response object.
+ * @param {NextFunction} [next] - The Express 'next' function to move to the next middleware in the stack.
+ */
+export function handleError(error: unknown, options?: SimplyJoiOptions, res?: Response, next?: NextFunction) {
+    let err: HttpError;
+    if(isJoiError(error)){
+        err = new HttpError(error.message)
+            .withCode('BAD_REQUEST')
+            .withStatus(400);
+    } else {
+        err = new HttpError('Internal server error')
+            .withCode('INTERNAL_SERVER_ERROR')
+            .withStatus(500);
+    }
+
+    if(options?.nextOnError){
+        next(err);
+    } else {
+        res.status(err.status).json({
+            code: err.code,
+            status: err.status,
+            message: err.message,
+        });
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export { validate, Targets } from './validate';
-
+export { validate } from './validate';
+export { Targets, SimplyJoiOptions } from './interfaces';

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,0 +1,40 @@
+/**
+ * Interface representing options to customize the behavior of the validation middleware.
+ * 
+ * @property nextOnError - Determines whether the middleware passes control to the next 
+ *                         middleware in the stack when a validation error occurs. If true,
+ *                         the next middleware is invoked, passing the error object. If false
+ *                         or undefined, an error response is immediately returned.
+ */
+export interface SimplyJoiOptions {
+    /**
+     * Determines whether the middleware passes control to the next middleware in the stack 
+     * when a validation error occurs. If true, the next middleware is invoked, passing the 
+     * error object. If false or undefined, an error response is immediately returned.
+     */
+    nextOnError: boolean;
+}
+
+/**
+ * Enumeration for the possible targets of HTTP request validation.
+ * @readonly
+ * @enum {string}
+ * 
+ * @property {string} BODY - Represents the body of the HTTP request.
+ * @property {string} QUERY - Represents the query parameters of the HTTP request.
+ * @property {string} HEADERS - Represents the headers of the HTTP request.
+ *
+ * @example
+ * const target = Targets.BODY; // This will make the middleware validate the body of the request
+ */
+export enum Targets {
+    BODY = 'body',
+    QUERY = 'query',
+    HEADERS = 'headers',
+}
+
+
+export enum HttpCodes {
+    INTERNAL = 'INTERNAL_SERVER_ERROR',
+    BAD_REQUEST = 'BAD_REQUEST'
+} 

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,7 +1,7 @@
 import { NextFunction, Request, Response, RequestHandler } from 'express';
 import { Schema, ValidationOptions, assert, isError as isJoiError } from 'joi';
-import { HttpError } from '@supercharge/http-errors/dist';
 import { SimplyJoiOptions, Targets } from './interfaces';
+import { handleError } from './helpers/handleError';
 
 
 /**
@@ -30,25 +30,8 @@ export function validate(schema: Schema, target: Targets, joiOptions?: Validatio
             assert(data, schema, joiOptions);
             next();
         } catch (error: unknown) {
-            let err: HttpError;
-            if(isJoiError(error)){
-                err = new HttpError(error.message)
-                    .withCode('BAD_REQUEST')
-                    .withStatus(400);
-            } else {
-                err = new HttpError('Internal server error')
-                    .withCode('INTERNAL_SERVER_ERROR')
-                    .withStatus(500);
-            }
-            if(options?.nextOnError){
-                next(err);
-            } else {
-                res.status(err.status).json({
-                    code: err.code,
-                    status: err.status,
-                    message: err.message,
-                });
-            }
+            handleError(error, options, res, next);
         }
     };
 }
+

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,26 +1,33 @@
 import { NextFunction, Request, Response, RequestHandler } from 'express';
 import { Schema, ValidationOptions, assert, isError as isJoiError } from 'joi';
 import { HttpError } from '@supercharge/http-errors/dist';
-
-export enum Targets {
-    BODY = 'body',
-    QUERY = 'query',
-    HEADERS = 'headers',
-}
-
-export enum HttpCodes {
-    INTERNAL = 'INTERNAL_SERVER_ERROR',
-    BAD_REQUEST = 'BAD_REQUEST'
-} 
+import { SimplyJoiOptions, Targets } from './interfaces';
 
 
-
-export function validate(schema: Schema, target: Targets, options?: ValidationOptions): RequestHandler {
+/**
+ * Creates an Express middleware function to validate a specified part of the HTTP request against a Joi schema.
+ *
+ * @param {Schema} schema - The Joi schema to validate against.
+ * @param {Targets} target - The part of the HTTP request to validate. Must be one of Targets enum.
+ * @param {ValidationOptions} [joiOptions] - Optional Joi validation options.
+ * @param {SimplyJoiOptions} [options] - Optional options for the middleware behavior. 
+ *                                       If nextOnError is true, it will pass control to the next middleware on validation error.
+ *
+ * @returns {RequestHandler} Express middleware for validating request data.
+ *
+ * @throws {HttpError} Throws an HTTP error if the validation fails or an unexpected error occurs.
+ *
+ * @example
+ * router.get('/', validate(schema, Targets.QUERY, undefined, {nextOnError: true}), (req, res) => {
+ *     res.json({ message: 'Success' });
+ * });
+ */
+export function validate(schema: Schema, target: Targets, joiOptions?: ValidationOptions, options?: SimplyJoiOptions): RequestHandler {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     return (req: Request, res: Response, next: NextFunction) => {
         const data: unknown = req[target];
         try {
-            assert(data, schema, options);
+            assert(data, schema, joiOptions);
             next();
         } catch (error: unknown) {
             let err: HttpError;
@@ -33,11 +40,15 @@ export function validate(schema: Schema, target: Targets, options?: ValidationOp
                     .withCode('INTERNAL_SERVER_ERROR')
                     .withStatus(500);
             }
-            res.status(err.status).json({
-                code: err.code,
-                status: err.status,
-                message: err.message,
-            });
+            if(options?.nextOnError){
+                next(err);
+            } else {
+                res.status(err.status).json({
+                    code: err.code,
+                    status: err.status,
+                    message: err.message,
+                });
+            }
         }
     };
 }

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -1,7 +1,8 @@
 import * as express from 'express';
 import * as request from 'supertest';
 import * as Joi from 'joi';
-import { HttpCodes, validate, Targets } from '@src/validate';
+import { validate, Targets } from '@src/index';
+import { HttpCodes } from '@src/interfaces';
 
 const app = express();
 app.use(express.json());
@@ -11,9 +12,24 @@ const schema = Joi.object({
     email: Joi.string().email().required(),
 });
 
+app.post('/testNextOnError', validate(schema, Targets.BODY, undefined, { nextOnError: true }), (req, res) => {
+    res.json({ message: 'Success' });
+});
+
+
 app.post('/test', validate(schema, Targets.BODY), (req, res) => {
     res.json({ message: 'Success' });
 });
+
+app.use((err, req, res, next) => {
+    if (res.headersSent) {
+        return next(err);
+    }
+    res.status(err.status || 500);
+    res.json({ message: err.message });
+});
+
+
 
 describe('POST /test', () => {
     it('should return 400 if the body is invalid', async () => {
@@ -29,6 +45,26 @@ describe('POST /test', () => {
     it('should return 200 if the body is valid', async () => {
         const res = await request(app)
             .post('/test')
+            .send({ name: 'John Doe', email: 'john.doe@example.com' });
+
+        expect(res.status).toBe(200);
+        expect(res.body.message).toEqual('Success');
+    });
+});
+
+describe('POST /testNextOnError', () => {
+    it('should return 400 if the body is invalid and nextOnError is true', async () => {
+        const res = await request(app)
+            .post('/testNextOnError')
+            .send({ name: 'John Doe' }); // no email, so it should fail
+
+        expect(res.status).toBe(400);
+        expect(res.body.message).toMatch(/.*email.* is required/);
+    });
+
+    it('should return 200 if the body is valid and nextOnError is true', async () => {
+        const res = await request(app)
+            .post('/testNextOnError')
             .send({ name: 'John Doe', email: 'john.doe@example.com' });
 
         expect(res.status).toBe(200);

--- a/test/validateRequest.test.ts
+++ b/test/validateRequest.test.ts
@@ -1,4 +1,5 @@
-import { validate, Targets } from '@src/validate'; 
+import { validate, Targets } from '@src/index'; 
+import { HttpError } from '@supercharge/http-errors/dist/http-error';
 import { Request, Response, NextFunction } from 'express';
 import * as Joi from 'joi';
 
@@ -62,4 +63,33 @@ describe('validate', () => {
         expect(mockResponse.status).toHaveBeenCalledWith(500);
         expect(mockResponse.json).toHaveBeenCalled();
     });
+
+    it('calls next with the error when validation fails and nextOnError is set to true', () => {
+        const schema = Joi.object({
+            foo: Joi.string().required(),
+        });
+    
+        mockRequest.body = { baz: 'qux' };
+    
+        validate(schema, Targets.BODY, undefined, { nextOnError: true })(mockRequest as Request, mockResponse as Response, nextFunction);
+    
+        expect(nextFunction).toHaveBeenCalledWith(expect.any(HttpError));
+    });
+    
+    it('calls next with the error when an unexpected error occurs and nextOnError is set to true', () => {
+        const schema = Joi.object({
+            foo: Joi.string().required(),
+        });
+        jest.spyOn(Joi, 'assert').mockImplementationOnce(() => {
+            throw new Error('test error');
+        });
+    
+        // This will cause an error because the schema is a string and not an object.
+        mockRequest.body = 'not an object';
+    
+        validate(schema, Targets.BODY, undefined, { nextOnError: true })(mockRequest as Request, mockResponse as Response, nextFunction);
+    
+        expect(nextFunction).toHaveBeenCalledWith(expect.any(HttpError));
+    });
+    
 });


### PR DESCRIPTION
# v0.2.0
## Summary
This pull request introduces the nextOnError option in the SimplyJoiOptions interface. When nextOnError is set to true, the Express 'next' function is invoked with the validation error. This is useful in cases where developers want to pass control to a subsequent middleware in case of validation errors instead of sending an HTTP response directly from the validation middleware.

Furthermore, this PR also includes a refactoring of the error handling logic. The error handling logic has been abstracted out into its own handleError function to improve readability and maintainability. The function creates a new HttpError based on the type of error encountered and handles the error according to the nextOnError option.

## Changes

- Added nextOnError option to SimplyJoiOptions interface.
- Abstracted error handling logic into handleError function.
- Updated unit tests to cover the new functionality.
- Updated jsdoc for validate function and SimplyJoiOptions interface.
- Updated README to document the new nextOnError option.
- How Has This Been Tested?
- Unit tests have been updated and added to cover the new functionality. All tests are passing.